### PR TITLE
Update bug report template labels and tiers

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -52,10 +52,12 @@ body:
   - type: dropdown
     id: tier
     attributes:
-      label: Accelerate Tier
+      label: License Tier
       options:
         - Community
         - Trial
+        - Pro
+        - Plus
         - Business
         - Enterprise
     validations:
@@ -68,7 +70,7 @@ body:
   - type: input
     id: version
     attributes:
-      label: Accelerate Version
+      label: Tool/Control Version
       placeholder: e.g. v11.x.x
   - type: textarea
     id: logs


### PR DESCRIPTION
Clarify and generalize fields in the bug report template: rename "Accelerate Tier" to "License Tier" and add "Pro" and "Plus" options to the dropdown; rename "Accelerate Version" to "Tool/Control Version" to better reflect the reported component. These changes improve form clarity for reporters.