### PR TITLE
Update Avalonia Pro demo package versions

### DIFF
--- a/AvaloniaProDemo/AvaloniaProDemo.csproj
+++ b/AvaloniaProDemo/AvaloniaProDemo.csproj
@@ -25,18 +25,18 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="12.0.1" />
-        <PackageReference Include="Avalonia.Controls.Markdown" Version="12.0.0" />
-        <PackageReference Include="Avalonia.Controls.Markdown.TextMate" Version="12.0.0" />
-        <PackageReference Include="Avalonia.Controls.MediaPlayer" Version="12.0.1" />
-        <PackageReference Include="Avalonia.Controls.TreeDataGrid" Version="12.0.0-beta3" />
-        <PackageReference Include="Avalonia.Controls.VirtualKeyboard" Version="12.0.0" />
-        <PackageReference Include="Avalonia.Controls.WebView" Version="12.0.0" />
-        <PackageReference Include="Avalonia.Desktop" Version="12.0.1" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.1" />
-        <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.1" />
+        <PackageReference Include="Avalonia" Version="12.0.5" />
+        <PackageReference Include="Avalonia.Controls.Markdown" Version="12.1.5" />
+        <PackageReference Include="Avalonia.Controls.Markdown.TextMate" Version="12.1.5" />
+        <PackageReference Include="Avalonia.Controls.MediaPlayer" Version="12.0.4" />
+        <PackageReference Include="Avalonia.Controls.TreeDataGrid" Version="12.0.3" />
+        <PackageReference Include="Avalonia.Controls.VirtualKeyboard" Version="12.0.1" />
+        <PackageReference Include="Avalonia.Controls.WebView" Version="12.0.1" />
+        <PackageReference Include="Avalonia.Desktop" Version="12.0.5" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.5" />
+        <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.5" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.1">
+        <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3">
             <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
             <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
         </PackageReference>

--- a/AvaloniaProDemo/Views/Markdown/MarkdownDemoView.axaml
+++ b/AvaloniaProDemo/Views/Markdown/MarkdownDemoView.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:documents="using:Avalonia.Controls.Documents"
              xmlns:vm="using:AvaloniaProDemo.ViewModels.Markdown"
              xmlns:textMate="clr-namespace:Avalonia.Controls;assembly=Avalonia.Controls.Markdown.TextMate"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
@@ -13,6 +14,10 @@
     </UserControl.Resources>
 
     <UserControl.Styles>
+        <Style Selector="documents|MarkdownCodeBlock">
+            <Setter Property="Highlighter" Value="{StaticResource textMateHighlighter}"/>
+        </Style>
+
         <Style Selector="Button.active">
             <Setter Property="Background" Value="{DynamicResource AccentBrush}"/>
             <Setter Property="Foreground" Value="White"/>
@@ -108,7 +113,6 @@
                     ClipToBounds="True">
                 <ScrollViewer HorizontalScrollBarVisibility="Disabled">
                     <Markdown Text="{Binding MarkdownText}"
-                              CodeHighlighter="{StaticResource textMateHighlighter}"
                               Margin="16"/>
                 </ScrollViewer>
             </Border>
@@ -124,7 +128,6 @@
                     ClipToBounds="True">
                 <ScrollViewer HorizontalScrollBarVisibility="Disabled">
                     <Markdown Text="{Binding MarkdownText}"
-                              CodeHighlighter="{StaticResource textMateHighlighter}"
                               Margin="16"/>
                 </ScrollViewer>
             </Border>


### PR DESCRIPTION
## Summary
- Update the demo to the current Avalonia 12 / Avalonia Pro package versions available on NuGet
- Move Markdown code block highlighting to the newer `MarkdownCodeBlock.Highlighter` style hook required by the updated Markdown package

## Verification
- `dotnet build .\AvaloniaProDemo.slnx -c Debug`
- Ran the demo on .NET SDK 10.0.301 with `AVALONIA_LICENSE_KEY` set
- Opened the Media Player page; it remains alive/responding after updating `Avalonia.Controls.MediaPlayer` from 12.0.1 to 12.0.4
- `dotnet list .\AvaloniaProDemo\AvaloniaProDemo.csproj package --outdated` reports no updates from the configured NuGet sources

Note: the build still reports existing obsolete `TextBox.Watermark` warnings in the demo XAML.